### PR TITLE
removing print function

### DIFF
--- a/client/perffarm-client.py
+++ b/client/perffarm-client.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
 
         # clone repository and build the sources
         repository = GitRepository(url=GIT_URL, path=REPOSITORY_PATH)
-        print(repository.current_branch())
+        #print(repository.current_branch())
 
         #if GIT_CLONE:
         #    repository.clone_or_update()


### PR DESCRIPTION
the print function right after 'git repo' causes the error log: fatal: Not a git repository (or any of the parent directories) error.

To clean the log, I commented the print function so that it won't check .git file in 'Postgres' repo when executing commands in this repo.